### PR TITLE
Fix compatibility with newer libnx releases

### DIFF
--- a/source/hooks/game.c
+++ b/source/hooks/game.c
@@ -93,7 +93,7 @@ void ExitAndroidGame(int code) {
   so_unload();
   // die
   // exit(0); // doesn't actually exit?
-  extern void NORETURN __libnx_exit(int rc);
+  extern void NX_NORETURN __libnx_exit(int rc);
   __libnx_exit(0);
 }
 


### PR DESCRIPTION
Otherwise it doesn't compile.

```
/mnt/d/ASwitch/max_nx/source/hooks/game.c: In function 'ExitAndroidGame':
/mnt/d/ASwitch/max_nx/source/hooks/game.c:96:24: error: expected '=', ',', ';', 'asm' or '__attribute__' before '__libnx_exit'
   96 |   extern void NORETURN __libnx_exit(int rc);
      |                        ^~~~~~~~~~~~
/mnt/d/ASwitch/max_nx/source/hooks/game.c:96:24: error: implicit declaration of function '__libnx_exit' [-Wimplicit-function-declaration]
/mnt/d/ASwitch/max_nx/source/hooks/game.c:96:37: error: expected expression before 'int'
   96 |   extern void NORETURN __libnx_exit(int rc);
      |                                     ^~~
make[1]: *** [/opt/devkitpro/devkitA64/base_rules:22: game.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:157: build] Error 2
```